### PR TITLE
fixes migrate phpunit conf

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -178,3 +178,4 @@ fabric.properties
 
 # Box
 dist/
+.qodo

--- a/composer.json
+++ b/composer.json
@@ -5,7 +5,8 @@
     "bin": ["bin/console"],
     "autoload": {
         "psr-4": {
-            "App\\": "src/"
+            "App\\": "src/",
+            "Tests\\": "tests/"
         }
     },
     "require": {

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,32 +1,26 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-  bootstrap="vendor/autoload.php"
-  backupGlobals="false"
-  backupStaticAttributes="false"
-  colors="true"
-  convertErrorsToExceptions="true"
-  convertNoticesToExceptions="true"
-  convertWarningsToExceptions="true"
-  executionOrder="random"
-  processIsolation="false"
-  stopOnFailure="true"
-  xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd">
-
-  <coverage>
-    <include>
-      <directory suffix=".php">src/</directory>
-    </include>
-  </coverage>
-
+         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/11.3/phpunit.xsd"
+         bootstrap="vendor/autoload.php"
+         backupGlobals="false"
+         colors="true"
+         executionOrder="random"
+         processIsolation="false"
+         stopOnFailure="true"
+         cacheDirectory=".phpunit.cache"
+         backupStaticProperties="false">
   <testsuites>
     <testsuite name="Project Test Suite">
       <directory>tests</directory>
     </testsuite>
   </testsuites>
-
   <php>
     <ini name="error_reporting" value="-1"/>
     <server name="APP_ENV" value="test" force="true"/>
   </php>
-
+  <source>
+    <include>
+      <directory suffix=".php">src/</directory>
+    </include>
+  </source>
 </phpunit>

--- a/tests/App/KernelTest.php
+++ b/tests/App/KernelTest.php
@@ -2,4 +2,12 @@
 
 namespace Tests\App;
 
+use PHPUnit\Framework\TestCase;
 
+class KernelTest extends TestCase
+{
+    public function test(): void
+    {
+        $this->assertTrue(true);
+    }
+}


### PR DESCRIPTION
This pull request includes several changes to improve the test configuration and structure of the project. The most important changes include adding a new namespace for tests, updating the PHPUnit configuration, and adding a basic test case.

Improvements to test configuration:

* [`composer.json`](diffhunk://#diff-d2ab9925cad7eac58e0ff4cc0d251a937ecf49e4b6bf57f8b95aab76648a9d34L8-R9): Added the `Tests\` namespace to the `psr-4` autoload section.
* [`phpunit.xml.dist`](diffhunk://#diff-e35810879ec42bdd81797b3ccb72f6de28a8b4a0e3bfdba43183e133e866b892R3-R25): Updated the PHPUnit configuration to use the latest schema, added a cache directory, and restructured the source inclusion for coverage.

Addition of a basic test case:

* [`tests/App/KernelTest.php`](diffhunk://#diff-03eb41630aea0c1870c586d9b4aa21723fef176d8fb838f79ef913de4970421fR5-R13): Added a new test case class `KernelTest` with a basic test method to assert `true`.